### PR TITLE
docs(admin): closeout documentation and version alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Suite Version Track (Current Cycle)
+### Changed
 
-- Active suite baseline is `V0.5.0` during in-progress capability work.
-- On final closeout/check-in of this feature cycle, suite version advances to `V0.6.0`.
-- `V0.6.0` will be composed of component versions finalized at feature closeout.
+- Post-release follow-up items only.
 
-### NovelWriter (In Progress)
+## [1.2.0] - 2026-04-19
 
-- Started NovelWriter stabilization work on `feature/novelwriter-schema-stabilization`.
+### Added
+
+- Administrative closeout alignment for release/checklist documentation and version metadata consistency checks.
+
+### Changed
+
+- Finalized NovelWriter stabilization release as `v0.3.4`.
+- Aligned HerbalBookForge release references to `v0.9.5`.
+- Bumped GitHub Actions workflow dependencies to `actions/checkout@v6` and `actions/setup-node@v6`.
+- Updated release closeout documentation to reflect current GitHub issue/PR state.
+
+### Fixed
+
 - Fixed invalid HTML body structure and duplicate loading indicator IDs in NovelWriter.
 - Added missing improvement status handler and corrected tab navigation label/state behavior for request log and consolidated breakdowns.
 - Added schema-aligned session export metadata (`schemaVersion`, `sourceTool`, `sourceVersion`, `exportedAt`) in NovelWriter exports.
@@ -64,7 +74,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### NovelWriter
 
-- **v0.3.3** - Latest stable release with full feature set
+- **v0.3.4** - Latest stable release with schema-aligned export/import hardening and workflow fixes
+- **v0.3.3** - Prior stable release
 - **v0.3.0** - Added chapter editing capabilities
 - **v0.2.0** - Added subplot management
 - **v0.1.0** - Initial character development features
@@ -83,7 +94,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### HerbalBookForge
 
-- **v0.9.3** - Latest stable release
+- **v0.9.5** - Latest stable release
+- **v0.9.3** - Prior stable release
 - **v0.9.0** - Added safety guidelines
 - **v0.8.0** - Enhanced herbal expertise prompts
 

--- a/CURRENT_RELEASE_SSDL_STATUS.md
+++ b/CURRENT_RELEASE_SSDL_STATUS.md
@@ -5,7 +5,7 @@ This file backfills the Secure SDLC checklist for the current capability release
 ## Release Snapshot
 
 - Release scope (current): NovelWriter stabilization, shared-schema alignment updates, smoke/regression harness hardening, and release-process documentation hardening.
-- Status: Closeout in progress (feature merged to `main`; final tag and GitHub governance closure still pending).
+- Status: Closeout documentation aligned on `main`; final release tag and post-merge validation evidence are pending.
 - Baseline policy template: `FEATURE_RELEASE_SSDL_CHECKLIST.md`
 - Suite version baseline for this active cycle: `V0.5.0`.
 - Suite version target at final closeout/check-in: `V0.6.0`.
@@ -107,7 +107,7 @@ This file backfills the Secure SDLC checklist for the current capability release
 - [ ] Run post-merge verification on trunk.
   - Pending closeout.
 - [ ] Close milestone, close addressed issues, and clean up merged branches.
-  - Partial: Merged feature branch was cleaned up; issue/milestone closure is pending GitHub token permissions.
+  - Partial: Addressed issue and administrative PR cleanup are complete; milestone/tag publication remains pending.
 
 ## 7) Post-Release Governance
 
@@ -137,4 +137,6 @@ This file backfills the Secure SDLC checklist for the current capability release
 - Deleted remote branch `feature/novelwriter-schema-stabilization`.
 - Sanitized local workflow/task configuration to remove hardcoded API key usage.
 - Could not execute final trunk validation suites in this environment because `XAI_API_KEY` is not set.
-- Could not close GitHub issue #3 from CLI due token permission (`Resource not accessible by personal access token`).
+- Issue #3 was closed from GitHub UI after implementation validation.
+- Dependabot PRs #1 and #2 were superseded by commit `2266939` and closed with comments.
+- Added explicit closeout policy note to keep documentation and version metadata aligned during feature-branch closeout.

--- a/FEATURE_RELEASE_SSDL_CHECKLIST.md
+++ b/FEATURE_RELEASE_SSDL_CHECKLIST.md
@@ -59,6 +59,10 @@ Use this checklist for any feature/capability release that changes code, configu
 - [ ] Tag the exact commit that passed final required tests.
 - [ ] If any commit is added after final pass, rerun required validation before tagging.
 - [ ] Publish release notes with links to tag, key PRs/issues, and evidence.
+- [ ] Run documentation/version alignment audit before tagging:
+	- Verify top-level docs (`README.md`, `CHANGELOG.md`, launcher labels) match current tool versions.
+	- Verify closeout trackers reflect actual GitHub issue/PR closure state.
+	- Verify suite version metadata (`package.json` and changelog release section) are synchronized.
 - [ ] Merge approved branches to trunk in dependency-safe order.
 - [ ] Run post-merge verification on trunk.
 - [ ] Close milestone, close addressed issues, and clean up merged branches.
@@ -80,3 +84,4 @@ Use this checklist for any feature/capability release that changes code, configu
 - Evidence locations (logs/reports/artifacts):
 - Security/config/data checks performed:
 - Open risks and mitigations:
+- Documentation/version alignment checks completed (README/changelog/launcher/closeout docs):

--- a/HerbalBookForge/README.md
+++ b/HerbalBookForge/README.md
@@ -42,7 +42,7 @@ A specialized AI-powered book creation tool designed for crafting herbal medicin
 
 ## Version
 
-Current version: 0.9.3
+Current version: 0.9.5
 
 ## Important Notes
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Static HTML/JavaScript tools for AI-assisted writing and book editing.
 
-Current tool releases: NovelWriter 0.3.3, BookEditor 0.4.0, BookDecomposer 0.2.0, HerbalBookForge 0.9.3.
+Current tool releases: NovelWriter 0.3.4, BookEditor 0.4.0, BookDecomposer 0.2.0, HerbalBookForge 0.9.5.
 
 ## Quick Start
 

--- a/RELEASE_CLOSEOUT_REPORT_2026-04-19.md
+++ b/RELEASE_CLOSEOUT_REPORT_2026-04-19.md
@@ -25,30 +25,24 @@ Close out the current NovelWriter/schema stabilization capability cycle by mergi
 - Main branch push result: successful
 - Remote feature branch delete result: successful
 
-## Open GitHub Items Checked
+## GitHub Items Closure Snapshot
 
-- Open PRs:
-  - #1 `ci(deps): bump actions/setup-node from 4 to 6`
-  - #2 `ci(deps): bump actions/checkout from 4 to 6`
-- Open issue:
-  - #3 `Define and implement shared versioned novel schema`
+- Issue #3 `Define and implement shared versioned novel schema`: CLOSED
+- PR #1 `ci(deps): bump actions/setup-node from 4 to 6`: CLOSED (superseded by direct trunk update)
+- PR #2 `ci(deps): bump actions/checkout from 4 to 6`: CLOSED (superseded by direct trunk update)
 
 ## Blockers Encountered
 
-- GitHub CLI token does not have permissions to close issues in this repository:
-  - `Resource not accessible by personal access token (closeIssue)`
 - Final post-merge trunk smoke/regression run was not executable in this environment because `XAI_API_KEY` is not set.
 
 ## Required Manual Follow-Up
 
 1. Set `XAI_API_KEY` in the release runner environment and execute final required post-merge suites on `main`.
-2. Close issue #3 if validation confirms all acceptance criteria are met.
-3. Triage/open dependency PRs #1 and #2 as separate maintenance work (not part of this capability release scope).
-4. Perform final version cut/tag/release publication once required suite pass is recorded.
+2. Perform final version cut/tag/release publication once required suite pass is recorded.
 
 ## Current Closeout State
 
 - Branch merge and trunk publication: complete.
 - Documentation and release governance capture: complete.
-- Issue closure in GitHub UI/API: pending permissions.
+- Issue and administrative PR closure: complete.
 - Final release tag and publication: pending final required test execution.

--- a/index.html
+++ b/index.html
@@ -42,10 +42,10 @@
 <body>
     <div class="container">
         <h1>Writing Tools</h1>
-        <a href="./NovelWriter/NovelWriter.html">Launch Novel Writer</a>
+        <a href="./NovelWriter/NovelWriter.html">Launch Novel Writer V.0.3.4</a>
         <a href="./BookEditor/BookEditor.html">Launch Book Editor V.0.4.0</a>
         <a href="./BookDecomposer/BookDecomposer.html">Launch Book Decomposer V.0.2.0</a>
-        <a href="./HerbalBookForge/HerbalBookForge.html">Launch HerbalBookForge V.0.9.3</a>
+        <a href="./HerbalBookForge/HerbalBookForge.html">Launch HerbalBookForge V.0.9.5</a>
     </div>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-book-tools",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Static HTML/JavaScript tools for AI-assisted writing and book editing",
   "main": "index.html",
   "scripts": {


### PR DESCRIPTION
## Summary
- align release and tool version references across README/changelog/launcher/tool docs
- refresh closeout docs to reflect current GitHub issue/PR closure state
- add explicit SSDLC checklist step for documentation/version alignment during closeout

Closes #4